### PR TITLE
Error fixes: Dead debian:jessie apt-repositories and SSHD privilege separation

### DIFF
--- a/kdc-server/Dockerfile
+++ b/kdc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:latest
 
 EXPOSE 749 88/udp
 

--- a/kdc-ssh-server/Dockerfile
+++ b/kdc-ssh-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:latest
 
 EXPOSE 749 88 22
 

--- a/ssh-container/Dockerfile
+++ b/ssh-container/Dockerfile
@@ -14,3 +14,5 @@ COPY sshd_config /etc/ssh/sshd_config
 # configuration for the SSH client
 COPY ssh_config /etc/ssh/ssh_config 
 
+# missing privilege separation directory fix
+RUN mkdir -p /run/sshd && chmod 755 /run/sshd

--- a/ssh-container/Dockerfile
+++ b/ssh-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:latest
 
 EXPOSE 22
 

--- a/ssh-container/sshd_config
+++ b/ssh-container/sshd_config
@@ -9,7 +9,7 @@ Port 22
 Protocol 2
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
+# HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security


### PR DESCRIPTION
# Dead debian:jessie apt-repositories
**Error Message**
```shell
 > [ssh-container-ssh-server 2/9] RUN apt-get -qq update:
#0 4.284 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.66.132 80]
#0 4.284
#0 4.284 W: Failed to fetch http://deb.debian.org/debian/dists/jessie/main/binary-amd64/Packages  404  Not Found
#0 4.284
#0 4.284 W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found
#0 4.284
#0 4.284 E: Some index files failed to download. They have been ignored, or old ones used instead.
```

**Fix**
- Change distro from deb:jess to ubuntu:latest

# SSHD privilege separation
**Error Message**
```shell
2023-12-18 18:38:23 Missing privilege separation directory: /run/sshd
```

**Fix**
- Adding command to the ssh-container Dockerfile which creates the required /run/sshd directory and sets the respective permissons.
```shell
RUN mkdir -p /run/sshd && chmod 755 /run/sshd
```